### PR TITLE
USB: fix CDC endpoints

### DIFF
--- a/cores/arduino/USB/USBDesc.h
+++ b/cores/arduino/USB/USBDesc.h
@@ -28,11 +28,11 @@
 #define CDC_DATA_INTERFACE	1	// CDC Data
 #define CDC_ENDPOINT_ACM	1
 #define CDC_ENDPOINT_OUT	2
-#define CDC_ENDPOINT_IN		3
+#define CDC_ENDPOINT_IN		2
 
 // HID
 #define HID_INTERFACE		2   // HID
-#define HID_ENDPOINT_INT	4
+#define HID_ENDPOINT_INT	3
 
 // Defined string description
 #define IMANUFACTURER	1


### PR DESCRIPTION
- fix in_endpoint buffer size (was too big)
- use the same EP for CDC_ENDPOINT_OUT and CDC_ENDPOINT_IN (different buffers)
- fix CDC_ENDPOINT_IN ep type

to test this PR:
sketch: https://gist.github.com/facchinm/322f0190e1800b48732f
PC utility: https://gist.github.com/facchinm/177bdf48b0d4143e9737
