### PR TITLE
use different EP for CDC IN and OUT

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -176,11 +176,9 @@ int Serial_::available(void)
 {
 	ring_buffer *buffer = &cdc_rx_buffer;
 	if (buffer->full) {
-		USB->DEVICE.DeviceEndpoint[2].EPINTENSET.reg = ~USB_DEVICE_EPINTENCLR_RXSTP;
 		return CDC_SERIAL_BUFFER_SIZE;
 	}
 	if (buffer->head == buffer->tail) {
-		USB->DEVICE.DeviceEndpoint[2].EPINTENSET.reg = USB_DEVICE_EPINTENCLR_RXSTP;
 		USB->DEVICE.DeviceEndpoint[2].EPINTENSET.reg = USB_DEVICE_EPINTENCLR_TRCPT(1);
 	}
 	return (uint32_t)(CDC_SERIAL_BUFFER_SIZE + buffer->head - buffer->tail) % CDC_SERIAL_BUFFER_SIZE;

--- a/cores/arduino/USB/USBDesc.h
+++ b/cores/arduino/USB/USBDesc.h
@@ -28,11 +28,11 @@
 #define CDC_DATA_INTERFACE	1	// CDC Data
 #define CDC_ENDPOINT_ACM	1
 #define CDC_ENDPOINT_OUT	2
-#define CDC_ENDPOINT_IN		2
+#define CDC_ENDPOINT_IN		3
 
 // HID
 #define HID_INTERFACE		2   // HID
-#define HID_ENDPOINT_INT	3
+#define HID_ENDPOINT_INT	4
 
 // Defined string description
 #define IMANUFACTURER	1


### PR DESCRIPTION
the `accept()` returning zero followed by a `read()` was triggering an HardFault if both the functions used different banks of the same endpoint. Maybe some `nop` could solve or mitigate the issue but we need more testing
Revert using two different EP in the meanwhile 
